### PR TITLE
fix(response): return `errors` alongside `data`

### DIFF
--- a/lib/neuron/response.ex
+++ b/lib/neuron/response.ex
@@ -11,7 +11,7 @@ defmodule Neuron.Response do
       :ok,
       %Response{
         status_code: response.status_code,
-        body: parse_body(response)["data"],
+        body: parse_body(response),
         headers: response.headers
       }
     }

--- a/test/neuron/response_test.exs
+++ b/test/neuron/response_test.exs
@@ -29,7 +29,7 @@ defmodule Neuron.ResponseTest do
       result = Response.handle({:ok, response})
 
       expected_result = %Response{
-        body: %{"users" => []},
+        body: %{ "data" => %{"users" => []}},
         headers: response.headers,
         status_code: response.status_code
       }

--- a/test/neuron/response_test.exs
+++ b/test/neuron/response_test.exs
@@ -29,7 +29,27 @@ defmodule Neuron.ResponseTest do
       result = Response.handle({:ok, response})
 
       expected_result = %Response{
-        body: %{ "data" => %{"users" => []}},
+        body: %{"data" => %{"users" => []}},
+        headers: response.headers,
+        status_code: response.status_code
+      }
+
+      assert result == {:ok, expected_result}
+    end
+  end
+
+  describe "when successful response but with errors in body" do
+    setup do
+      %{
+        response: build_response(200, ~s/{"data": null, "errors": "stuff"}/)
+      }
+    end
+
+    test "returns the parsed Response struct", %{response: response} do
+      result = Response.handle({:ok, response})
+
+      expected_result = %Response{
+        body: %{"data" => nil, "errors" => "stuff"},
         headers: response.headers,
         status_code: response.status_code
       }


### PR DESCRIPTION
When the GraphQL throws an error and then responds with 200, it sends the errors in `errors` alongside `data`.  For example, an unauthenticated request might have this response:

```
{
  "data": null,
  "errors": [
    {
      "message": "Not authenticated",
      "locations": [
        {
          "line": 2,
          "column": 3
        }
      ],
      "path": [
        "..."
      ]
    }
  ]
}
```

BREAKING CHANGE

Now the value of `response.body` will be `%{ data: ..., errors: ... }` instead of `%{ ... }` (only returning `data`).