### PR TITLE
Ability to set connection options

### DIFF
--- a/lib/neuron/config.ex
+++ b/lib/neuron/config.ex
@@ -20,6 +20,7 @@ defmodule Neuron.Config do
   def set(:global, nil) do
     Application.delete_env(:neuron, :neuron_url)
     Application.delete_env(:neuron, :neuron_headers)
+    Application.delete_env(:neuron, :neuron_connection_opts)
   end
 
   def set(:global, url: value) do
@@ -40,6 +41,15 @@ defmodule Neuron.Config do
     :ok
   end
 
+  def set(:global, connection_opts: value) do
+    Application.put_env(:neuron, :neuron_connection_opts, value)
+  end
+
+  def set(:process, connection_opts: value) do
+    Process.put(:neuron_connection_opts, value)
+    :ok
+  end
+
   @doc """
   gets url configuration value for Neuron
 
@@ -57,6 +67,7 @@ defmodule Neuron.Config do
   """
   def get(:headers), do: get(:neuron_headers)
   def get(:url), do: get(:neuron_url)
+  def get(:connection_opts), do: get(:neuron_connection_opts)
 
   def get(key) do
     key
@@ -70,6 +81,7 @@ defmodule Neuron.Config do
 
   def current_context(:headers), do: current_context(:neuron_headers)
   def current_context(:url), do: current_context(:neuron_url)
+  def current_context(:connection_opts), do: current_context(:neuron_connection_opts)
 
   def current_context(key) do
     if Process.get(key, nil), do: :process, else: :global

--- a/lib/neuron/connection.ex
+++ b/lib/neuron/connection.ex
@@ -10,7 +10,8 @@ defmodule Neuron.Connection do
     HTTPoison.post(
       url,
       query,
-      build_headers()
+      build_headers(),
+      connection_opts()
     )
   end
 
@@ -21,5 +22,9 @@ defmodule Neuron.Connection do
 
   defp headers() do
     Config.get(:headers) || []
+  end
+
+  defp connection_opts() do
+    Config.get(:connection_opts) || []
   end
 end

--- a/test/neuron/config_test.exs
+++ b/test/neuron/config_test.exs
@@ -35,9 +35,11 @@ defmodule Neuron.ConfigTest do
     test "Can set multiple settings" do
       Config.set(url: "testurl")
       Config.set(headers: [name: "val"])
+      Config.set(connection_opts: [foo: "bar"])
 
       assert Config.get(:url) == "testurl"
       assert Config.get(:headers) == [name: "val"]
+      assert Config.get(:connection_opts) == [foo: "bar"]
     end
   end
 end

--- a/test/neuron/connection_test.exs
+++ b/test/neuron/connection_test.exs
@@ -13,28 +13,28 @@ defmodule Neuron.ConnectionTest do
 
     test "sets content-type as default header", %{url: url, query: query} do
       with_mock HTTPoison,
-        post: fn _url, _query, _headers ->
+        post: fn _url, _query, _headers, _opts ->
           %HTTPoison.Response{}
         end do
         Connection.post(url, query)
-        assert called(HTTPoison.post(url, query, "Content-Type": "application/graphql"))
+        assert called(HTTPoison.post(url, query, ["Content-Type": "application/graphql"], []))
       end
     end
 
     test "overwrites content type if supplied", %{url: url, query: query} do
       with_mock HTTPoison,
-        post: fn _url, _query, _headers ->
+        post: fn _url, _query, _headers, _opts ->
           %HTTPoison.Response{}
         end do
         Neuron.Config.set(headers: ["Content-Type": "application/json"])
         Connection.post(url, query)
-        assert called(HTTPoison.post(url, query, "Content-Type": "application/json"))
+        assert called(HTTPoison.post(url, query, ["Content-Type": "application/json"], []))
       end
     end
 
     test "with basic auth", %{url: url, query: query} do
       with_mock HTTPoison,
-        post: fn _url, _query, _headers ->
+        post: fn _url, _query, _headers, _opts ->
           %HTTPoison.Response{}
         end do
         Neuron.Config.set(headers: [hackney: [basic_auth: [user: "password"]]])
@@ -44,8 +44,11 @@ defmodule Neuron.ConnectionTest do
                  HTTPoison.post(
                    url,
                    query,
-                   "Content-Type": "application/graphql",
-                   hackney: [basic_auth: [user: "password"]]
+                   [
+                     "Content-Type": "application/graphql",
+                     hackney: [basic_auth: [user: "password"]]
+                   ],
+                   []
                  )
                )
       end
@@ -53,7 +56,7 @@ defmodule Neuron.ConnectionTest do
 
     test "with custom headers", %{url: url, query: query} do
       with_mock HTTPoison,
-        post: fn _url, _query, _headers ->
+        post: fn _url, _query, _headers, _opts ->
           %HTTPoison.Response{}
         end do
         Neuron.Config.set(headers: ["X-CUSTOM": "value"])
@@ -63,8 +66,27 @@ defmodule Neuron.ConnectionTest do
                  HTTPoison.post(
                    url,
                    query,
-                   "Content-Type": "application/graphql",
-                   "X-CUSTOM": "value"
+                   ["Content-Type": "application/graphql", "X-CUSTOM": "value"],
+                   []
+                 )
+               )
+      end
+    end
+
+    test "with custom connection options", %{url: url, query: query} do
+      with_mock HTTPoison,
+        post: fn _url, _query, _headers, _opts ->
+          %HTTPoison.Response{}
+        end do
+        Neuron.Config.set(connection_opts: [timeout: 50_000])
+        Connection.post(url, query)
+
+        assert called(
+                 HTTPoison.post(
+                   url,
+                   query,
+                   ["Content-Type": "application/graphql"],
+                   timeout: 50_000
                  )
                )
       end


### PR DESCRIPTION
I have a particularly slow request, for which I need to add a `timeout` argument to the HTTPoison call. That is done by using the `post/4` method instead of `/post/3`, which is currenly used

This PR allows me to set `Config.set(:connection_opts)` to enable that. This is just a quick patch for my current issue, but I'm happy to work a bit more on this (add tests, docs, etc) before merging, if necessary