### PR TITLE
Basic Fragment Registration

### DIFF
--- a/lib/neuron.ex
+++ b/lib/neuron.ex
@@ -1,5 +1,5 @@
 defmodule Neuron do
-  alias Neuron.{Response, Connection, Config}
+  alias Neuron.{Response, Connection, Config, Fragment}
 
   @moduledoc """
   Neuron is a GraphQL client for elixir.
@@ -46,7 +46,7 @@ defmodule Neuron do
   def query(query_string) do
     query_string
     |> construct_query_string()
-    |> include_fragments()
+    |> Fragment.insert_into_query()
     |> run()
   end
 
@@ -64,75 +64,8 @@ defmodule Neuron do
   def mutation(mutation_string) do
     mutation_string
     |> construct_mutation_string()
-    |> include_fragments()
+    |> Fragment.insert_into_query()
     |> run()
-  end
-
-  @doc ~S"""
-  registers a fragment that will automatically be added to future mutations and queries that require it
-
-  ## Example
-
-  ```elixir
-  Neuron.register_fragment("\"\"
-    NameParts on Person {
-      firstName
-      lastName
-    }
-  \"\"")
-  ```
-  """
-
-  @spec register_fragment(query_string :: String.t()) :: :ok
-  def register_fragment(query_string), do: register_fragment(:global, query_string)
-
-  @spec register_fragment(context :: :global | :process, query_string :: String.t()) :: :ok
-
-  def register_fragment(:global, query_string) do
-    fragment = query_string |> process_fragment
-    stored_fragments = Application.get_all_env(:neuron) |> Access.get(:fragments, [])
-    Application.put_env(:neuron, :fragments, [fragment | stored_fragments])
-  end
-
-  def register_fragment(:process, query_string) do
-    fragment = query_string |> process_fragment
-    stored_fragments = Process.get() |> Access.get(:fragments, [])
-    Process.put(:fragments, [fragment | stored_fragments])
-  end
-
-  defp process_fragment(query_string) do
-    fragment_name =
-      Regex.run(~r/^(\w+)/, query_string, capture: :first) |> List.first() |> String.to_atom()
-
-    fragment = query_string |> construct_fragment_string
-
-    {fragment_name, fragment}
-  end
-
-  defp include_fragments(query_string) do
-    stored_fragments =
-      (Application.get_all_env(:neuron) |> Access.get(:fragments, [])) ++
-        (Process.get() |> Access.get(:fragments, []))
-
-    fragments_to_add =
-      query_string
-      |> find_fragments
-      |> Enum.map(&List.keyfind(stored_fragments, &1, 0, &1))
-
-    missing_fragments = fragments_to_add |> Enum.filter(&is_atom/1) |> Enum.map(&Atom.to_string/1)
-
-    if Enum.count(missing_fragments) > 0, do: raise("Fragments #{missing_fragments} not found")
-
-    fragments_to_add
-    |> Enum.map(&elem(&1, 1))
-    |> Enum.reduce(query_string, &"#{&1} \n #{&2}")
-  end
-
-  # TODO : Ignore '...<word>' in strings within the graphql querys
-  defp find_fragments(query_string) do
-    Regex.scan(~r/(?<=\.\.\.)\w+/, query_string)
-    |> List.flatten()
-    |> Enum.map(&String.to_atom/1)
   end
 
   defp run(body) do
@@ -151,10 +84,6 @@ defmodule Neuron do
 
   defp construct_mutation_string(mutation_string) do
     "mutation #{mutation_string}"
-  end
-
-  defp construct_fragment_string(fragment_string) do
-    "fragment #{fragment_string}"
   end
 
   defp url do

--- a/lib/neuron/fragment.ex
+++ b/lib/neuron/fragment.ex
@@ -22,13 +22,12 @@ defmodule Neuron.Fragment do
   @spec register(context :: :global | :process, query_string :: String.t()) :: :ok
   def register(context, query_string) do
     fragment = query_string |> process_fragment_string
-    stored_fragments = Store.get(context, :fragments)
+    stored_fragments = Store.get(context, :fragments, [])
     Store.set(context, :fragments, [fragment | stored_fragments])
   end
 
   defp process_fragment_string(query_string) do
-    fragment_name =
-      Regex.run(~r/^(\w+)/, query_string, capture: :first) |> List.first() |> String.to_atom()
+    fragment_name = Regex.run(~r/^(?:\W*)(\w+)/, query_string) |> List.last() |> String.to_atom()
 
     fragment = query_string |> construct_fragment_string
 

--- a/lib/neuron/fragment.ex
+++ b/lib/neuron/fragment.ex
@@ -53,7 +53,7 @@ defmodule Neuron.Fragment do
 
   # TODO : Ignore '...<word>' in strings within the graphql querys
   defp find_in_query(query_string) do
-    Regex.scan(~r/(?<=\.\.\.)\w+/, query_string)
+    Regex.scan(~r/(?<=\.\.\.)\w+(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/, query_string)
     |> List.flatten()
     |> Enum.map(&String.to_atom/1)
   end

--- a/lib/neuron/fragment.ex
+++ b/lib/neuron/fragment.ex
@@ -51,7 +51,6 @@ defmodule Neuron.Fragment do
     |> Enum.reduce(query_string, &"#{&1} \n #{&2}")
   end
 
-  # TODO : Ignore '...<word>' in strings within the graphql querys
   defp find_in_query(query_string) do
     Regex.scan(~r/(?<=\.\.\.)\w+(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/, query_string)
     |> List.flatten()

--- a/lib/neuron/fragment.ex
+++ b/lib/neuron/fragment.ex
@@ -6,14 +6,14 @@ defmodule Neuron.Fragment do
 
   ## Example
 
-  ```elixir
-  Neuron.register("\"\"
-    NameParts on Person {
-      firstName
-      lastName
-    }
-  \"\"")
-  ```
+  iex> Neuron.Fragment.register("
+  ...>  NameParts on Person {
+  ...>    firstName
+  ...>    lastName
+  ...>  }
+  ...> ")
+  :ok
+
   """
 
   @spec register(query_string :: String.t()) :: :ok
@@ -34,6 +34,7 @@ defmodule Neuron.Fragment do
     {fragment_name, fragment}
   end
 
+  @doc false
   def insert_into_query(query_string) do
     stored_fragments = Store.get(:global, :fragments, []) ++ Store.get(:process, :fragments, [])
 
@@ -44,7 +45,7 @@ defmodule Neuron.Fragment do
 
     missing_fragments = fragments_to_add |> Enum.filter(&is_atom/1) |> Enum.map(&Atom.to_string/1)
 
-    if Enum.count(missing_fragments) > 0, do: raise("Fragments #{missing_fragments} not found")
+    if Enum.any?(missing_fragments), do: raise("Fragments #{missing_fragments} not found")
 
     fragments_to_add
     |> Enum.map(&elem(&1, 1))

--- a/lib/neuron/fragment.ex
+++ b/lib/neuron/fragment.ex
@@ -1,0 +1,65 @@
+defmodule Neuron.Fragment do
+  alias Neuron.Store
+
+  @doc ~S"""
+  registers a fragment that will automatically be added to future mutations and queries that require it
+
+  ## Example
+
+  ```elixir
+  Neuron.register("\"\"
+    NameParts on Person {
+      firstName
+      lastName
+    }
+  \"\"")
+  ```
+  """
+
+  @spec register(query_string :: String.t()) :: :ok
+  def register(query_string), do: register(:global, query_string)
+
+  @spec register(context :: :global | :process, query_string :: String.t()) :: :ok
+  def register(context, query_string) do
+    fragment = query_string |> process_fragment_string
+    stored_fragments = Store.get(context, :fragments)
+    Store.set(context, :fragments, [fragment | stored_fragments])
+  end
+
+  defp process_fragment_string(query_string) do
+    fragment_name =
+      Regex.run(~r/^(\w+)/, query_string, capture: :first) |> List.first() |> String.to_atom()
+
+    fragment = query_string |> construct_fragment_string
+
+    {fragment_name, fragment}
+  end
+
+  def insert_into_query(query_string) do
+    stored_fragments = Store.get(:global, :fragments, []) ++ Store.get(:process, :fragments, [])
+
+    fragments_to_add =
+      query_string
+      |> find_in_query
+      |> Enum.map(&List.keyfind(stored_fragments, &1, 0, &1))
+
+    missing_fragments = fragments_to_add |> Enum.filter(&is_atom/1) |> Enum.map(&Atom.to_string/1)
+
+    if Enum.count(missing_fragments) > 0, do: raise("Fragments #{missing_fragments} not found")
+
+    fragments_to_add
+    |> Enum.map(&elem(&1, 1))
+    |> Enum.reduce(query_string, &"#{&1} \n #{&2}")
+  end
+
+  # TODO : Ignore '...<word>' in strings within the graphql querys
+  defp find_in_query(query_string) do
+    Regex.scan(~r/(?<=\.\.\.)\w+/, query_string)
+    |> List.flatten()
+    |> Enum.map(&String.to_atom/1)
+  end
+
+  defp construct_fragment_string(fragment_string) do
+    "fragment #{fragment_string}"
+  end
+end

--- a/lib/neuron/store.ex
+++ b/lib/neuron/store.ex
@@ -1,0 +1,75 @@
+defmodule Neuron.Store do
+  @moduledoc """
+  This module provides a simple way to interface with the process and
+  application environmental variables, acting as a simple KV store.
+  """
+
+  @doc """
+  sets neuron application/process environmental variables
+
+  ## Examples
+    iex> Neuron.Store.set(:my_key, "value")
+    :ok
+  """
+  @spec set(key :: atom(), value :: any()) :: :ok
+  def set(key, value), do: set(:global, key, value)
+
+  @spec set(context :: :global | :process, value :: keyword()) :: :ok
+  def set(:global, key, value) do
+    Application.put_env(:neuron, key, value)
+  end
+
+  def set(:process, key, value) do
+    Process.put(key, value)
+    :ok
+  end
+
+  @doc """
+  returs neuron application/process environmental variables
+
+  ## Examples
+    iex> Neuron.Store.get(:my_key)
+    "value"
+  """
+  @spec get(key :: atom()) :: any()
+  def get(key), do: get(:global, key)
+
+  @spec get(context :: :global | :process, key :: atom()) :: any()
+  def get(context, key), do: get(context, key, nil)
+
+  @spec get(context :: :global | :process, key :: atom(), default :: any()) :: any()
+  def get(:global, key, default), do: Application.get_env(:neuron, key, default)
+  def get(:process, key, default), do: Process.get(key, default)
+
+  @doc """
+  deletes neuron application/process environmental variables
+
+  ## Examples
+    iex> Neuron.Store.delete(:my_key)
+    :ok
+  """
+  @spec delete(key :: atom()) :: any()
+  def delete(key), do: delete(:global, key)
+
+  @spec delete(context :: :global | :process, key :: atom()) :: :ok
+  def delete(:global, key) do
+    Application.delete_env(:neuron, key)
+  end
+
+  def delete(:process, key) do
+    Process.delete(key)
+    :ok
+  end
+
+  @doc """
+  gets the context of a given neuron application/process environmental variable
+
+  ## Examples
+    iex> Neuron.Store.current_context(:my_key)
+    :global
+  """
+  @spec current_context(key :: atom()) :: :global | :process
+  def current_context(key) do
+    if Process.get(key, nil), do: :process, else: :global
+  end
+end

--- a/lib/neuron/store.ex
+++ b/lib/neuron/store.ex
@@ -28,6 +28,8 @@ defmodule Neuron.Store do
   returs neuron application/process environmental variables
 
   ## Examples
+    iex> Neuron.Store.set(:my_key, "value")
+    :ok
     iex> Neuron.Store.get(:my_key)
     "value"
   """

--- a/lib/neuron/store.ex
+++ b/lib/neuron/store.ex
@@ -2,6 +2,8 @@ defmodule Neuron.Store do
   @moduledoc """
   This module provides a simple way to interface with the process and
   application environmental variables, acting as a simple KV store.
+
+  WARNING: this module is not intended to be used outside of this library.
   """
 
   @doc """

--- a/test/neuron/config_test.exs
+++ b/test/neuron/config_test.exs
@@ -14,7 +14,6 @@ defmodule Neuron.ConfigTest do
       url = "https://example.com/graph"
       Config.set(:global, url: url)
 
-      assert Config.current_context(:url) == :global
       assert Config.get(:url) == url
     end
 
@@ -24,11 +23,9 @@ defmodule Neuron.ConfigTest do
       spawn(fn ->
         Config.set(:process, url: url)
 
-        assert Config.current_context(:url) == :process
         assert Config.get(:url) == url
       end)
 
-      assert Config.current_context(:url) == :global
       assert Config.get(:url) == nil
     end
 

--- a/test/neuron/fragment_test.exs
+++ b/test/neuron/fragment_test.exs
@@ -1,0 +1,50 @@
+defmodule Neuron.FragmentTest do
+  use ExUnit.Case
+  doctest Neuron.Fragment
+
+  alias Neuron.Fragment
+
+  @test_fragment """
+    Name for Person {
+      firstName,
+      lastName
+    }
+  """
+
+  @test_query """
+    users {
+      ...Name
+    }
+  """
+
+  describe "when no fragments are registered" do
+    test "query containing fragments error" do
+      assert_raise RuntimeError, fn ->
+        Neuron.query(@test_query)
+      end
+    end
+  end
+
+  describe "when name fragment is registered" do
+    setup [:register_name_fragment, :add_url]
+
+    test "fragments are retrievable by name" do
+      assert Neuron.Store.get(:fragments) |> Keyword.get(:Name) == "fragment #{@test_fragment}"
+    end
+
+    test "correct fragments are inserted into queries" do
+      assert Fragment.insert_into_query(@test_query) ==
+               "fragment #{@test_fragment} \n #{@test_query}"
+    end
+  end
+
+  defp register_name_fragment(_context) do
+    Fragment.register(@test_fragment)
+  end
+
+  defp add_url(_context) do
+    url = "www.example.com/graph"
+    Neuron.Config.set(:global, url: url)
+    %{url: url}
+  end
+end

--- a/test/neuron/fragment_test.exs
+++ b/test/neuron/fragment_test.exs
@@ -11,30 +11,56 @@ defmodule Neuron.FragmentTest do
     }
   """
 
-  @test_query """
-    users {
+  @test_query_without_fragment """
+    query users {
+      firstName,
+      lastName
+    }
+  """
+
+  @test_query_with_fragment """
+    query users {
       ...Name
     }
   """
 
+  @test_mutation_with_quoted_fragment """
+    mutation user(email: "...Name@gmail.com") {
+      firstName
+      lastName
+    }
+  """
+
   describe "when no fragments are registered" do
+    setup [:clear_stored_fragments]
+
     test "query containing fragments error" do
       assert_raise RuntimeError, fn ->
-        Neuron.query(@test_query)
+        Neuron.query(@test_query_with_fragment)
       end
     end
   end
 
   describe "when name fragment is registered" do
-    setup [:register_name_fragment, :add_url]
+    setup [:clear_stored_fragments, :register_name_fragment]
 
     test "fragments are retrievable by name" do
       assert Neuron.Store.get(:fragments) |> Keyword.get(:Name) == "fragment #{@test_fragment}"
     end
 
     test "correct fragments are inserted into queries" do
-      assert Fragment.insert_into_query(@test_query) ==
-               "fragment #{@test_fragment} \n #{@test_query}"
+      correct_request = "fragment #{@test_fragment} \n #{@test_query_with_fragment}"
+      assert Fragment.insert_into_query(@test_query_with_fragment) == correct_request
+    end
+
+    test "fragment not inserted if not needed" do
+      assert Fragment.insert_into_query(@test_query_without_fragment) ==
+               @test_query_without_fragment
+    end
+
+    test "fragment not inserted if fragment inside string" do
+      assert Fragment.insert_into_query(@test_mutation_with_quoted_fragment) ==
+               @test_mutation_with_quoted_fragment
     end
   end
 
@@ -42,9 +68,8 @@ defmodule Neuron.FragmentTest do
     Fragment.register(@test_fragment)
   end
 
-  defp add_url(_context) do
-    url = "www.example.com/graph"
-    Neuron.Config.set(:global, url: url)
-    %{url: url}
+  defp clear_stored_fragments(_context) do
+    Neuron.Store.delete(:process, :fragments)
+    Neuron.Store.delete(:global, :fragments)
   end
 end

--- a/test/neuron/store_test.exs
+++ b/test/neuron/store_test.exs
@@ -1,0 +1,96 @@
+defmodule Neuron.StoreTest do
+  use ExUnit.Case
+  doctest Neuron.Store
+
+  alias Neuron.Store
+
+  describe "set" do
+    setup [:clear_store]
+
+    test "inserts into process store" do
+      assert :ok == Store.set(:process, :hi, "hola")
+      assert "hola" == Process.get(:hi)
+    end
+
+    test "inserts into application store" do
+      assert :ok == Store.set(:global, :bye, "ciao")
+      assert "ciao" == Application.get_env(:neuron, :bye)
+    end
+
+    test "inserts into application store by default" do
+      assert :ok == Store.set(:wow, "bam")
+      assert "bam" == Application.get_env(:neuron, :wow)
+    end
+  end
+
+  describe "get" do
+    setup [:clear_store, :seed_store_data]
+
+    test "returns default value if key not found" do
+      assert nil == Store.get(:global, :unknown)
+      assert nil == Store.get(:process, :unknown)
+      assert :missing == Store.get(:global, :unknown, :missing)
+      assert :missing == Store.get(:process, :unknown, :missing)
+    end
+
+    test "returns stored elements from process" do
+      assert "hola" == Store.get(:process, :hi)
+    end
+
+    test "returns stored elements from application" do
+      assert "ciao" == Store.get(:global, :bye)
+    end
+
+    test "returns from application store by default" do
+      assert "qux" == Store.get(:baz)
+    end
+  end
+
+  describe "delete" do
+    setup [:clear_store, :seed_store_data]
+
+    test "removes keys from process store" do
+      assert :ok == Store.delete(:process, :hi)
+      assert :not_found == Process.get(:hi, :not_found)
+    end
+
+    test "removes keys from application store" do
+      assert :ok == Store.delete(:global, :bye)
+      assert :not_found == Application.get_env(:neuron, :bye, :not_found)
+    end
+
+    test "deletes from application store by default" do
+      assert :ok == Store.delete(:baz)
+      assert :not_found == Application.get_env(:neuron, :baz, :not_found)
+    end
+  end
+
+  describe "current_context" do
+    setup [:clear_store, :seed_store_data]
+
+    test "returns correct context for keys" do
+      assert :process == Store.current_context(:hi)
+      assert :global == Store.current_context(:bye)
+    end
+
+    test "returns global for unknown keys" do
+      assert :global == Store.current_context(:unknown)
+    end
+  end
+
+  defp clear_store(_context) do
+    Application.delete_env(:neuron, :hi)
+    Application.delete_env(:neuron, :bye)
+    Process.delete(:hi)
+    Process.delete(:bye)
+    :ok
+  end
+
+  defp seed_store_data(_context) do
+    Process.put(:hi, "hola")
+    Application.put_env(:neuron, :bye, "ciao")
+    Process.put(:foo, "bar")
+    Application.put_env(:neuron, :baz, "qux")
+    :ok
+  end
+end


### PR DESCRIPTION
This is a basic implementation of fragments addressing #1 . It automatically adds
fragments to the process / global store and pulls from them as necessary
when mutations / queries are sent.

Things to be done:
- [x] Make fragment features independent module
- [x] Refactor out storage into separate module 
- [x] Add tests for fragment registration and parsing
- [x] Identify if "fragment" is within a string, and ignore parsing ( todo in code )

Some of these items do clutter neuron.ex. I'm wondering if this should reside in its own module?