### PR TITLE
feat(query): Allow to send queries as json

### DIFF
--- a/lib/neuron.ex
+++ b/lib/neuron.ex
@@ -79,14 +79,26 @@ defmodule Neuron do
   end
 
   defp construct_query_string(query_string) do
-    "query #{query_string}"
+    if as_json() do
+      Poison.encode!(%{query: query_string})
+    else
+      "query #{query_string}"
+    end
   end
 
   defp construct_mutation_string(mutation_string) do
-    "mutation #{mutation_string}"
+    if as_json() do
+      Poison.encode!(%{mutation: mutation_string})
+    else
+      "mutation #{mutation_string}"
+    end
   end
 
   defp url do
     Config.get(:url)
+  end
+
+  defp as_json do
+    Config.get(:as_json)
   end
 end

--- a/lib/neuron/config.ex
+++ b/lib/neuron/config.ex
@@ -26,6 +26,7 @@ defmodule Neuron.Config do
   - url: graphql endpoint url
   - headers: headers to be sent in the request
   - connection_opts: additional options to be passed to HTTPoison
+  - as_json: sends requests as json instead of graphql format (e.g Github API v4 only accepts json)
 
   ## Examples
 
@@ -47,6 +48,7 @@ defmodule Neuron.Config do
   def set(context, url: value), do: Store.set(context, :neuron_url, value)
   def set(context, headers: value), do: Store.set(context, :neuron_headers, value)
   def set(context, connection_opts: value), do: Store.set(context, :neuron_connection_opts, value)
+  def set(context, as_json: value), do: Store.set(context, :neuron_as_json, value)
 
   @doc """
   gets configuration value for Neuron
@@ -70,6 +72,7 @@ defmodule Neuron.Config do
   def get(:headers), do: get(:neuron_headers)
   def get(:url), do: get(:neuron_url)
   def get(:connection_opts), do: get(:neuron_connection_opts)
+  def get(:as_json), do: get(:neuron_as_json)
 
   def get(key) do
     key

--- a/lib/neuron/connection.ex
+++ b/lib/neuron/connection.ex
@@ -16,7 +16,8 @@ defmodule Neuron.Connection do
   end
 
   defp build_headers() do
-    ["Content-Type": "application/graphql"]
+    Config.get(:as_json)
+    |> base_headers()
     |> Keyword.merge(headers())
   end
 
@@ -27,4 +28,7 @@ defmodule Neuron.Connection do
   defp connection_opts() do
     Config.get(:connection_opts) || []
   end
+
+  defp base_headers(true), do: []
+  defp base_headers(_), do: ["Content-Type": "application/graphql"]
 end

--- a/test/neuron/connection_test.exs
+++ b/test/neuron/connection_test.exs
@@ -91,5 +91,18 @@ defmodule Neuron.ConnectionTest do
                )
       end
     end
+
+    test "with as_json: true", %{url: url, query: query} do
+      with_mock HTTPoison,
+        post: fn _url, _query, _headers, _opts ->
+          %HTTPoison.Response{}
+        end do
+        Neuron.Config.set(as_json: true)
+        Connection.post(url, query)
+        Neuron.Config.set(as_json: false)
+
+        assert called(HTTPoison.post(url, query, [], []))
+      end
+    end
   end
 end

--- a/test/neuron_test.exs
+++ b/test/neuron_test.exs
@@ -21,6 +21,18 @@ defmodule NeuronTest do
         assert called(Connection.post(url, "query users { name }"))
       end
     end
+
+    test "calls as json if as_json: true", %{url: url} do
+      with_mock Connection,
+        post: fn _url, _body ->
+          {:ok, %{body: ~s/{"data": {"users": []}}/, status_code: 200, headers: []}}
+        end do
+        Neuron.Config.set(as_json: true)
+        Neuron.query("users { name }")
+        Neuron.Config.set(as_json: false)
+        assert called(Connection.post(url, "{\"query\":\"users { name }\"}"))
+      end
+    end
   end
 
   describe "mutation/1" do
@@ -32,6 +44,19 @@ defmodule NeuronTest do
         end do
         Neuron.mutation(~s/addUser(name: "unai")/)
         assert called(Connection.post(url, ~s/mutation addUser(name: "unai")/))
+      end
+    end
+
+    test "calls as json if as_json: true", %{url: url} do
+      with_mock Connection,
+        post: fn _url, _body ->
+          {:ok,
+           %{body: ~s/{"data": {"addUser": {"name": "unai"}}}/, status_code: 200, headers: []}}
+        end do
+        Neuron.Config.set(as_json: true)
+        Neuron.mutation(~s/addUser(name: "unai")/)
+        Neuron.Config.set(as_json: false)
+        assert called(Connection.post(url, "{\"mutation\":\"addUser(name: \\\"unai\\\")\"}"))
       end
     end
   end


### PR DESCRIPTION
E.g Github API v4 only accepts json bodies.
You can now set `Neuron.Config.set(as_json: true)` for this.

Fixes #19