### PR TITLE
feat(options): Allow to override options per request

### DIFF
--- a/lib/neuron/connection.ex
+++ b/lib/neuron/connection.ex
@@ -6,29 +6,16 @@ defmodule Neuron.Connection do
     raise ArgumentError, message: "you need to supply an url"
   end
 
-  def post(url, query) do
+  def post(url, query, headers) do
     HTTPoison.post(
       url,
       query,
-      build_headers(),
+      headers,
       connection_opts()
     )
-  end
-
-  defp build_headers() do
-    Config.get(:as_json)
-    |> base_headers()
-    |> Keyword.merge(headers())
-  end
-
-  defp headers() do
-    Config.get(:headers) || []
   end
 
   defp connection_opts() do
     Config.get(:connection_opts) || []
   end
-
-  defp base_headers(true), do: []
-  defp base_headers(_), do: ["Content-Type": "application/graphql"]
 end

--- a/test/neuron/connection_test.exs
+++ b/test/neuron/connection_test.exs
@@ -11,62 +11,20 @@ defmodule Neuron.ConnectionTest do
       %{url: "http://www.example.com/graph", query: %{}}
     end
 
-    test "sets content-type as default header", %{url: url, query: query} do
-      with_mock HTTPoison,
-        post: fn _url, _query, _headers, _opts ->
-          %HTTPoison.Response{}
-        end do
-        Connection.post(url, query)
-        assert called(HTTPoison.post(url, query, ["Content-Type": "application/graphql"], []))
-      end
-    end
-
-    test "overwrites content type if supplied", %{url: url, query: query} do
-      with_mock HTTPoison,
-        post: fn _url, _query, _headers, _opts ->
-          %HTTPoison.Response{}
-        end do
-        Neuron.Config.set(headers: ["Content-Type": "application/json"])
-        Connection.post(url, query)
-        assert called(HTTPoison.post(url, query, ["Content-Type": "application/json"], []))
-      end
-    end
-
     test "with basic auth", %{url: url, query: query} do
       with_mock HTTPoison,
         post: fn _url, _query, _headers, _opts ->
           %HTTPoison.Response{}
         end do
-        Neuron.Config.set(headers: [hackney: [basic_auth: [user: "password"]]])
-        Connection.post(url, query)
+        Connection.post(url, query, hackney: [basic_auth: [user: "password"]])
 
         assert called(
                  HTTPoison.post(
                    url,
                    query,
                    [
-                     "Content-Type": "application/graphql",
                      hackney: [basic_auth: [user: "password"]]
                    ],
-                   []
-                 )
-               )
-      end
-    end
-
-    test "with custom headers", %{url: url, query: query} do
-      with_mock HTTPoison,
-        post: fn _url, _query, _headers, _opts ->
-          %HTTPoison.Response{}
-        end do
-        Neuron.Config.set(headers: ["X-CUSTOM": "value"])
-        Connection.post(url, query)
-
-        assert called(
-                 HTTPoison.post(
-                   url,
-                   query,
-                   ["Content-Type": "application/graphql", "X-CUSTOM": "value"],
                    []
                  )
                )
@@ -79,29 +37,9 @@ defmodule Neuron.ConnectionTest do
           %HTTPoison.Response{}
         end do
         Neuron.Config.set(connection_opts: [timeout: 50_000])
-        Connection.post(url, query)
+        Connection.post(url, query, [])
 
-        assert called(
-                 HTTPoison.post(
-                   url,
-                   query,
-                   ["Content-Type": "application/graphql"],
-                   timeout: 50_000
-                 )
-               )
-      end
-    end
-
-    test "with as_json: true", %{url: url, query: query} do
-      with_mock HTTPoison,
-        post: fn _url, _query, _headers, _opts ->
-          %HTTPoison.Response{}
-        end do
-        Neuron.Config.set(as_json: true)
-        Connection.post(url, query)
-        Neuron.Config.set(as_json: false)
-
-        assert called(HTTPoison.post(url, query, [], []))
+        assert called(HTTPoison.post(url, query, [], timeout: 50_000))
       end
     end
   end

--- a/test/neuron_test.exs
+++ b/test/neuron_test.exs
@@ -7,56 +7,109 @@ defmodule NeuronTest do
 
   setup do
     url = "www.example.com/graph"
-    Neuron.Config.set(:global, url: url)
-    %{url: url}
+    base_headers = ["Content-Type": "application/graphql"]
+    Neuron.Config.set(nil)
+    Neuron.Config.set(url: url)
+    %{url: url, base_headers: base_headers}
   end
 
   describe "query/1" do
-    test "calls the connection with correct url and query string", %{url: url} do
+    test "calls the connection with correct url and query string", %{
+      url: url,
+      base_headers: base_headers
+    } do
       with_mock Connection,
-        post: fn _url, _body ->
+        post: fn _url, _body, _headers ->
           {:ok, %{body: ~s/{"data": {"users": []}}/, status_code: 200, headers: []}}
         end do
         Neuron.query("users { name }")
-        assert called(Connection.post(url, "query users { name }"))
+        assert called(Connection.post(url, "query users { name }", base_headers))
       end
     end
 
     test "calls as json if as_json: true", %{url: url} do
       with_mock Connection,
-        post: fn _url, _body ->
+        post: fn _url, _body, _headers ->
           {:ok, %{body: ~s/{"data": {"users": []}}/, status_code: 200, headers: []}}
         end do
         Neuron.Config.set(as_json: true)
         Neuron.query("users { name }")
         Neuron.Config.set(as_json: false)
-        assert called(Connection.post(url, "{\"query\":\"users { name }\"}"))
+        assert called(Connection.post(url, "{\"query\":\"users { name }\"}", []))
+      end
+    end
+  end
+
+  describe "query/2" do
+    test "it takes all configs as arguments", %{base_headers: base_headers} do
+      url = "www.example.com/another/graph"
+      headers = ["X-test-header": 'my_header']
+
+      with_mock Connection,
+        post: fn _url, _body, _headers ->
+          {:ok, %{body: ~s/{"data": {"users": []}}/, status_code: 200, headers: []}}
+        end do
+        Neuron.query("users { name }", url: url, headers: headers)
+
+        assert called(
+                 Connection.post(
+                   url,
+                   "query users { name }",
+                   Keyword.merge(base_headers, headers)
+                 )
+               )
       end
     end
   end
 
   describe "mutation/1" do
-    test "calls the connection with correct url and query string", %{url: url} do
+    test "calls the connection with correct url and query string", %{
+      url: url,
+      base_headers: base_headers
+    } do
       with_mock Connection,
-        post: fn _url, _body ->
+        post: fn _url, _body, _headers ->
           {:ok,
            %{body: ~s/{"data": {"addUser": {"name": "unai"}}}/, status_code: 200, headers: []}}
         end do
         Neuron.mutation(~s/addUser(name: "unai")/)
-        assert called(Connection.post(url, ~s/mutation addUser(name: "unai")/))
+        assert called(Connection.post(url, ~s/mutation addUser(name: "unai")/, base_headers))
       end
     end
 
     test "calls as json if as_json: true", %{url: url} do
       with_mock Connection,
-        post: fn _url, _body ->
+        post: fn _url, _body, _headers ->
           {:ok,
            %{body: ~s/{"data": {"addUser": {"name": "unai"}}}/, status_code: 200, headers: []}}
         end do
         Neuron.Config.set(as_json: true)
         Neuron.mutation(~s/addUser(name: "unai")/)
         Neuron.Config.set(as_json: false)
-        assert called(Connection.post(url, "{\"mutation\":\"addUser(name: \\\"unai\\\")\"}"))
+
+        assert called(Connection.post(url, "{\"mutation\":\"addUser(name: \\\"unai\\\")\"}", []))
+      end
+    end
+  end
+
+  describe "mutation/2" do
+    test "it takes all configs as arguments", %{base_headers: base_headers} do
+      url = "www.example.com/another/graph"
+      headers = ["X-test-header": 'my_header']
+
+      with_mock Connection,
+        post: fn _url, _body, _headers ->
+          {:ok, %{body: ~s/{"data": {"users": []}}/, status_code: 200, headers: []}}
+        end do
+        Neuron.mutation(~s/addUser(name: "unai")/, url: url, headers: headers)
+
+        assert called(
+                 Connection.post(
+                   url,
+                   ~s/mutation addUser(name: "unai")/,
+                   Keyword.merge(base_headers, headers)
+                 )
+               )
       end
     end
   end


### PR DESCRIPTION
Fixes #18 


  You can now overwrite parameters set on `Neuron.Config` by passing them as options.

  ## Example

  ```elixir
  Neuron.query(
    \"""
    {
      films {
        title
      }
    }
    \""",
    url: "https://api.super.com/graph"
  )
  ```