### PR TITLE
use `application/json` when using `as_json` option

### DIFF
--- a/lib/neuron.ex
+++ b/lib/neuron.ex
@@ -139,6 +139,6 @@ defmodule Neuron do
     Keyword.get(options, :headers, Config.get(:headers) || [])
   end
 
-  defp base_headers(true), do: []
+  defp base_headers(true), do: ["Content-Type": "application/json"]
   defp base_headers(_), do: ["Content-Type": "application/graphql"]
 end


### PR DESCRIPTION
express-graphql server wants `application/json` content type when request is sent as json.

Without it the response is something like this:
```elixir
{:error,
 %Neuron.Response{
   body: %{
     "errors" => [
       %{
         "message" => "Must provide query string."
       }
     ]
   },
   headers: [
     {"Date", "Wed, 19 Sep 2018 18:25:11 GMT"},
     {"Content-Type", "application/json; charset=utf-8"},
     {"Content-Length", "232"},
     {"Connection", "keep-alive"},
     {"X-Powered-By", "Express"},
     {"Vary", "Origin"},
     {"ETag", "W/\"e8-u8d9rVg1yQAxpOKlfMB5/g\""},
     {"Server-Timing", "total;dur=0.810"}
   ],
   status_code: 400
 }}
```