### PR TITLE
fix: Use application/json content type with :as_json option

### DIFF
--- a/lib/neuron.ex
+++ b/lib/neuron.ex
@@ -139,6 +139,6 @@ defmodule Neuron do
     Keyword.get(options, :headers, Config.get(:headers) || [])
   end
 
-  defp base_headers(true), do: []
+  defp base_headers(true), do: ["Content-Type": "application/json"]
   defp base_headers(_), do: ["Content-Type": "application/graphql"]
 end

--- a/lib/neuron/config.ex
+++ b/lib/neuron/config.ex
@@ -30,7 +30,7 @@ defmodule Neuron.Config do
 
   ## Examples
 
-      iex> Neuron.Config.set(headers: ["name": "val"])
+      iex> Neuron.Config.set(headers: [name: "val"])
       :ok
 
       iex> Neuron.Config.set(:process, url: "http://example.com/graph")

--- a/test/neuron_test.exs
+++ b/test/neuron_test.exs
@@ -30,8 +30,7 @@ defmodule NeuronTest do
 
     test "calls as json if as_json: true", %{url: url, json_headers: json_headers} do
       with_mock Connection,
-        post: fn _url, _body, headers ->
-          IO.inspect(headers)
+        post: fn _url, _body, _headers ->
           {:ok, %{body: ~s/{"data": {"users": []}}/, status_code: 200, headers: []}}
         end do
         Neuron.Config.set(as_json: true)


### PR DESCRIPTION
at least [express-graphql](https://www.npmjs.com/package/express-graphql) server (probably not the only one) needs `application/json` as content type when request is sent as json.

Without it the response is something like this:
```elixir
{:error,
 %Neuron.Response{
   body: %{
     "errors" => [
       %{
         "message" => "Must provide query string."
       }
     ]
   },
   headers: [
     {"Date", "Wed, 19 Sep 2018 18:25:11 GMT"},
     {"Content-Type", "application/json; charset=utf-8"},
     {"Content-Length", "232"},
     {"Connection", "keep-alive"},
     {"X-Powered-By", "Express"},
     {"Vary", "Origin"},
     {"ETag", "W/\"e8-u8d9rVg1yQAxpOKlfMB5/g\""},
     {"Server-Timing", "total;dur=0.810"}
   ],
   status_code: 400
 }}
```