### PR TITLE
feat(response): return a meaningful error when response is not JSON

### DIFF
--- a/lib/neuron/json_parse_error.ex
+++ b/lib/neuron/json_parse_error.ex
@@ -1,0 +1,12 @@
+defmodule Neuron.JSONParseError do
+  @moduledoc """
+  Struct representation of a JSON parse error.
+  """
+
+  alias Neuron.Response
+
+  @type t :: %Neuron.JSONParseError{error: Map.t(), response: Response.t()}
+
+  defstruct response: %Response{},
+            error: nil
+end

--- a/lib/neuron/response.ex
+++ b/lib/neuron/response.ex
@@ -21,6 +21,7 @@ defmodule Neuron.Response do
     case Poison.decode(response.body, parse_options) do
       {:ok, body} -> build_response(%{response | body: body})
       {:error, error} -> handle_unparsable(response, error)
+      {:error, error, _} -> handle_unparsable(response, error)
     end
   end
 

--- a/lib/neuron/response.ex
+++ b/lib/neuron/response.ex
@@ -22,9 +22,7 @@ defmodule Neuron.Response do
     end
   end
 
-  def handle({:error, _} = response) do
-    response
-  end
+  def handle({:error, _} = response), do: response
 
   @doc false
   def build_response(%{status_code: 200} = response) do

--- a/lib/neuron/response.ex
+++ b/lib/neuron/response.ex
@@ -1,5 +1,8 @@
 defmodule Neuron.Response do
-  alias Neuron.Response
+  alias Neuron.{
+    Response,
+    JSONParseError
+  }
 
   @moduledoc """
   Struct representation of a query response.
@@ -12,33 +15,47 @@ defmodule Neuron.Response do
             headers: nil
 
   @doc false
-  def handle({:ok, %{status_code: 200} = response}) do
+  def handle({:ok, response}) do
+    case Poison.decode(response.body) do
+      {:ok, body} -> build_response(%{response | body: body})
+      {:error, error} -> handle_unparsable(response, error)
+    end
+  end
+
+  def handle({:error, _} = response) do
+    response
+  end
+
+  @doc false
+  def build_response(%{status_code: 200} = response) do
     {
       :ok,
       %Response{
         status_code: response.status_code,
-        body: parse_body(response),
+        body: response.body,
         headers: response.headers
       }
     }
   end
 
-  def handle({:ok, response}) do
+  def build_response(response) do
     {
       :error,
       %Response{
         status_code: response.status_code,
-        body: parse_body(response),
+        body: response.body,
         headers: response.headers
       }
     }
   end
 
-  def handle({:error, response}) do
-    {:error, response}
-  end
-
-  defp parse_body(response) do
-    Poison.decode!(response.body)
+  def handle_unparsable(response, error) do
+    {
+      :error,
+      %JSONParseError{
+        response: build_response(response),
+        error: error
+      }
+    }
   end
 end

--- a/test/neuron/response_test.exs
+++ b/test/neuron/response_test.exs
@@ -112,8 +112,11 @@ defmodule Neuron.ResponseTest do
       body = "<html><body>This is not the GraphQL URL</body></html>"
       raw_response = build_response(200, body)
 
-      assert {_, %{response: %Response{} = response}} = Response.handle({:ok, raw_response})
-      assert response == {:ok, raw_response}
+      assert {_, %{response: {:ok, %Response{} = response}}} =
+               Response.handle({:ok, raw_response})
+
+      assert response.body == raw_response.body
+      assert response.headers == raw_response.headers
     end
   end
 end

--- a/test/neuron/response_test.exs
+++ b/test/neuron/response_test.exs
@@ -1,7 +1,10 @@
 defmodule Neuron.ResponseTest do
   use ExUnit.Case
 
-  alias Neuron.Response
+  alias Neuron.{
+    Response,
+    JSONParseError
+  }
 
   def build_response(status_code, body) do
     %{
@@ -94,6 +97,23 @@ defmodule Neuron.ResponseTest do
       result = Response.handle({:error, "error message"})
 
       assert result == {:error, "error message"}
+    end
+  end
+
+  describe "when response not json parsable" do
+    test "returns a JSONParseError" do
+      body = "<html><body>This is not the GraphQL URL</body></html>"
+      raw_response = build_response(200, body)
+
+      assert {:error, %JSONParseError{}} = Response.handle({:ok, raw_response})
+    end
+
+    test "includes a response struct for debugging" do
+      body = "<html><body>This is not the GraphQL URL</body></html>"
+      raw_response = build_response(200, body)
+
+      assert {_, %{response: %Response{} = response}} = Response.handle({:ok, raw_response})
+      assert response == {:ok, raw_response}
     end
   end
 end


### PR DESCRIPTION
Let's say you have a typo in your API URL and the server tries to redirect you to a login page (this is exactly what happened in our case). Until now, Poison would raise an error and the information provided is not very helpful in finding the actual problem: Error parsing JSON, invalid Token at position 0 "<" - if you know what causes it, you still don't know what caused the error.

Returning {:error, %JSONParseError{}} makes debugging easier. It includes the response with the original body, so you can figure out what the problem was.