### PR TITLE
feat(decode): Added support for passing options to the json decoder

### DIFF
--- a/lib/neuron.ex
+++ b/lib/neuron.ex
@@ -101,7 +101,7 @@ defmodule Neuron do
   defp run(body, options) do
     body
     |> run_query(options)
-    |> Response.handle()
+    |> handle_response(options)
   end
 
   defp run_query(body, options) do
@@ -116,6 +116,11 @@ defmodule Neuron do
     Map.put(body, :variables, variables)
   end
 
+  defp handle_response(response, options) do
+    parse_options = parse_options(options)
+    Response.handle(response, parse_options)
+  end
+
   defp url(options) do
     Keyword.get(options, :url) || Config.get(:url)
   end
@@ -126,5 +131,9 @@ defmodule Neuron do
 
   defp headers(options) do
     Keyword.get(options, :headers, Config.get(:headers) || [])
+  end
+
+  defp parse_options(options) do
+    Keyword.get(options, :parse_options, Config.get(:parse_options) || [])
   end
 end

--- a/lib/neuron.ex
+++ b/lib/neuron.ex
@@ -117,8 +117,8 @@ defmodule Neuron do
   end
 
   defp handle_response(response, options) do
-    parse_options = parse_options(options)
-    Response.handle(response, parse_options)
+    parsed_options = parse_options(options)
+    Response.handle(response, parsed_options)
   end
 
   defp url(options) do

--- a/lib/neuron/config.ex
+++ b/lib/neuron/config.ex
@@ -35,7 +35,7 @@ defmodule Neuron.Config do
       iex> Neuron.Config.set(:process, url: "http://example.com/graph")
       :ok
 
-      iex> Neuron.Config.set(json_response_opts: [keys: :atoms])
+      iex> Neuron.Config.set(parse_options: [keys: :atoms])
       :ok
   """
 
@@ -43,7 +43,7 @@ defmodule Neuron.Config do
   def set(context, value)
 
   def set(:global, nil) do
-    [:neuron_url, :neuron_headers, :neuron_connection_opts, :neuron_json_response_opts]
+    [:neuron_url, :neuron_headers, :neuron_connection_opts, :neuron_parse_options]
     |> Enum.map(&Store.delete(:global, &1))
   end
 
@@ -51,8 +51,8 @@ defmodule Neuron.Config do
   def set(context, headers: value), do: Store.set(context, :neuron_headers, value)
   def set(context, connection_opts: value), do: Store.set(context, :neuron_connection_opts, value)
 
-  def set(context, json_response_opts: value),
-    do: Store.set(context, :neuron_json_response_opts, value)
+  def set(context, parse_options: value),
+    do: Store.set(context, :neuron_parse_options, value)
 
   @doc """
   gets configuration value for Neuron
@@ -76,7 +76,7 @@ defmodule Neuron.Config do
   def get(:headers), do: get(:neuron_headers)
   def get(:url), do: get(:neuron_url)
   def get(:connection_opts), do: get(:neuron_connection_opts)
-  def get(:json_response_opts), do: get(:neuron_json_response_opts)
+  def get(:parse_options), do: get(:neuron_parse_options)
 
   def get(key) do
     key

--- a/lib/neuron/config.ex
+++ b/lib/neuron/config.ex
@@ -34,19 +34,25 @@ defmodule Neuron.Config do
 
       iex> Neuron.Config.set(:process, url: "http://example.com/graph")
       :ok
+
+      iex> Neuron.Config.set(json_response_opts: [keys: :atoms])
+      :ok
   """
 
   @spec set(context :: :global | :process, value :: keyword()) :: :ok
   def set(context, value)
 
   def set(:global, nil) do
-    [:neuron_url, :neuron_headers, :neuron_connection_opts]
+    [:neuron_url, :neuron_headers, :neuron_connection_opts, :neuron_json_response_opts]
     |> Enum.map(&Store.delete(:global, &1))
   end
 
   def set(context, url: value), do: Store.set(context, :neuron_url, value)
   def set(context, headers: value), do: Store.set(context, :neuron_headers, value)
   def set(context, connection_opts: value), do: Store.set(context, :neuron_connection_opts, value)
+
+  def set(context, json_response_opts: value),
+    do: Store.set(context, :neuron_json_response_opts, value)
 
   @doc """
   gets configuration value for Neuron
@@ -70,6 +76,7 @@ defmodule Neuron.Config do
   def get(:headers), do: get(:neuron_headers)
   def get(:url), do: get(:neuron_url)
   def get(:connection_opts), do: get(:neuron_connection_opts)
+  def get(:json_response_opts), do: get(:neuron_json_response_opts)
 
   def get(key) do
     key

--- a/lib/neuron/response.ex
+++ b/lib/neuron/response.ex
@@ -1,5 +1,5 @@
 defmodule Neuron.Response do
-  alias Neuron.Response
+  alias Neuron.{Response, Config}
 
   @moduledoc """
   Struct representation of a query response.
@@ -39,6 +39,10 @@ defmodule Neuron.Response do
   end
 
   defp parse_body(response) do
-    Poison.decode!(response.body)
+    Poison.decode!(response.body, json_response_opts())
+  end
+
+  defp json_response_opts() do
+    Config.get(:json_response_opts) || []
   end
 end

--- a/lib/neuron/response.ex
+++ b/lib/neuron/response.ex
@@ -1,5 +1,5 @@
 defmodule Neuron.Response do
-  alias Neuron.{Response, Config}
+  alias Neuron.Response
 
   @moduledoc """
   Struct representation of a query response.
@@ -12,37 +12,34 @@ defmodule Neuron.Response do
             headers: nil
 
   @doc false
-  def handle({:ok, %{status_code: 200} = response}) do
+  def handle({:ok, %{status_code: 200} = response}, parse_options) do
     {
       :ok,
       %Response{
         status_code: response.status_code,
-        body: parse_body(response),
+        body: parse_body(response, parse_options),
         headers: response.headers
       }
     }
   end
 
-  def handle({:ok, response}) do
+  def handle({:ok, response}, parse_options) do
     {
       :error,
       %Response{
         status_code: response.status_code,
-        body: parse_body(response),
+        body: parse_body(response, parse_options),
         headers: response.headers
       }
     }
   end
 
-  def handle({:error, response}) do
+  def handle({:error, response}, _parse_options) do
     {:error, response}
   end
 
-  defp parse_body(response) do
-    Poison.decode!(response.body, parse_options())
+  defp parse_body(response, parse_options) do
+    Poison.decode!(response.body, parse_options)
   end
 
-  defp parse_options() do
-    Config.get(:parse_options) || []
-  end
 end

--- a/lib/neuron/response.ex
+++ b/lib/neuron/response.ex
@@ -39,10 +39,10 @@ defmodule Neuron.Response do
   end
 
   defp parse_body(response) do
-    Poison.decode!(response.body, json_response_opts())
+    Poison.decode!(response.body, parse_options())
   end
 
-  defp json_response_opts() do
-    Config.get(:json_response_opts) || []
+  defp parse_options() do
+    Config.get(:parse_options) || []
   end
 end

--- a/test/neuron/response_test.exs
+++ b/test/neuron/response_test.exs
@@ -26,7 +26,7 @@ defmodule Neuron.ResponseTest do
     end
 
     test "returns the parsed Response struct", %{response: response} do
-      result = Response.handle({:ok, response})
+      result = Response.handle({:ok, response}, [])
 
       expected_result = %Response{
         body: %{"data" => %{"users" => []}},
@@ -40,9 +40,7 @@ defmodule Neuron.ResponseTest do
     test "returns the parsed Response struct with atom keys in the body map", %{
       response: response
     } do
-      Neuron.Config.set(parse_options: [keys: :atoms])
-      result = Response.handle({:ok, response})
-      Neuron.Config.set(parse_options: nil)
+      result = Response.handle({:ok, response}, [keys: :atoms])
 
       expected_result = %Response{
         body: %{:data => %{:users => []}},
@@ -62,7 +60,7 @@ defmodule Neuron.ResponseTest do
     end
 
     test "returns the parsed Response struct", %{response: response} do
-      result = Response.handle({:ok, response})
+      result = Response.handle({:ok, response}, [])
 
       expected_result = %Response{
         body: %{"data" => nil, "errors" => "stuff"},
@@ -86,7 +84,7 @@ defmodule Neuron.ResponseTest do
     end
 
     test "returns the parsed Response struct with errors", %{response: response} do
-      result = Response.handle({:ok, response})
+      result = Response.handle({:ok, response}, [])
 
       expected_result = %Response{
         body: %{
@@ -107,7 +105,7 @@ defmodule Neuron.ResponseTest do
 
   describe "when error" do
     test "returns the error" do
-      result = Response.handle({:error, "error message"})
+      result = Response.handle({:error, "error message"}, [])
 
       assert result == {:error, "error message"}
     end

--- a/test/neuron/response_test.exs
+++ b/test/neuron/response_test.exs
@@ -40,9 +40,9 @@ defmodule Neuron.ResponseTest do
     test "returns the parsed Response struct with atom keys in the body map", %{
       response: response
     } do
-      Neuron.Config.set(json_response_opts: [keys: :atoms])
+      Neuron.Config.set(parse_options: [keys: :atoms])
       result = Response.handle({:ok, response})
-      Neuron.Config.set(json_response_opts: nil)
+      Neuron.Config.set(parse_options: nil)
 
       expected_result = %Response{
         body: %{:data => %{:users => []}},

--- a/test/neuron/response_test.exs
+++ b/test/neuron/response_test.exs
@@ -36,6 +36,21 @@ defmodule Neuron.ResponseTest do
 
       assert result == {:ok, expected_result}
     end
+
+    test "returns the parsed Response struct with atom keys in the body map", %{
+      response: response
+    } do
+      Neuron.Config.set(json_response_opts: [keys: :atoms])
+      result = Response.handle({:ok, response})
+
+      expected_result = %Response{
+        body: %{:data => %{:users => []}},
+        headers: response.headers,
+        status_code: response.status_code
+      }
+
+      assert result == {:ok, expected_result}
+    end
   end
 
   describe "when successful response but with errors in body" do

--- a/test/neuron/response_test.exs
+++ b/test/neuron/response_test.exs
@@ -42,6 +42,7 @@ defmodule Neuron.ResponseTest do
     } do
       Neuron.Config.set(json_response_opts: [keys: :atoms])
       result = Response.handle({:ok, response})
+      Neuron.Config.set(json_response_opts: nil)
 
       expected_result = %Response{
         body: %{:data => %{:users => []}},


### PR DESCRIPTION
There is currently no way of passing additional options to the json decoder (Poison). Such an option could be keys: :atoms.

This feature makes it possible to do this: `Neuron.Config.set(json_response_opts: [keys: :atoms])`

I've added a doctest for the Config setter and a response test confirming that the data returned is formatted according to the passed json_response_opts. All tests are passing.
