### PR TITLE
feat(options): Allow to override connection options per request

### DIFF
--- a/lib/neuron.ex
+++ b/lib/neuron.ex
@@ -107,7 +107,8 @@ defmodule Neuron do
   defp run_query(body, options) do
     url = url(options)
     headers = build_headers(options)
-    Connection.post(url, body, headers)
+    connection_opts = connection_options(options)
+    Connection.post(url, body, %{headers: headers, connection_opts: connection_opts})
   end
 
   defp build_body(query_string), do: %{query: query_string}
@@ -135,5 +136,9 @@ defmodule Neuron do
 
   defp parse_options(options) do
     Keyword.get(options, :parse_options, Config.get(:parse_options) || [])
+  end
+
+  defp connection_options(options) do
+    Keyword.get(options, :connection_opts, Config.get(:connection_opts) || [])
   end
 end

--- a/lib/neuron/connection.ex
+++ b/lib/neuron/connection.ex
@@ -1,21 +1,16 @@
 defmodule Neuron.Connection do
-  alias Neuron.Config
   @moduledoc false
 
   def post(nil, _) do
     raise ArgumentError, message: "you need to supply an url"
   end
 
-  def post(url, query, headers) do
+  def post(url, query, %{:headers => headers, :connection_opts => connection_opts}) do
     HTTPoison.post(
       url,
       query,
       headers,
-      connection_opts()
+      connection_opts
     )
-  end
-
-  defp connection_opts() do
-    Config.get(:connection_opts) || []
   end
 end

--- a/test/neuron/connection_test.exs
+++ b/test/neuron/connection_test.exs
@@ -16,15 +16,14 @@ defmodule Neuron.ConnectionTest do
         post: fn _url, _query, _headers, _opts ->
           %HTTPoison.Response{}
         end do
-        Connection.post(url, query, hackney: [basic_auth: [user: "password"]])
+        headers = [hackney: [basic_auth: [user: "password"]]]
+        Connection.post(url, query, %{headers: headers, connection_opts: []})
 
         assert called(
                  HTTPoison.post(
                    url,
                    query,
-                   [
-                     hackney: [basic_auth: [user: "password"]]
-                   ],
+                   headers,
                    []
                  )
                )
@@ -36,8 +35,8 @@ defmodule Neuron.ConnectionTest do
         post: fn _url, _query, _headers, _opts ->
           %HTTPoison.Response{}
         end do
-        Neuron.Config.set(connection_opts: [timeout: 50_000])
-        Connection.post(url, query, [])
+        connection_opts = [timeout: 50_000]
+        Connection.post(url, query, %{headers: [], connection_opts: connection_opts})
 
         assert called(HTTPoison.post(url, query, [], timeout: 50_000))
       end

--- a/test/neuron_test.exs
+++ b/test/neuron_test.exs
@@ -28,7 +28,7 @@ defmodule NeuronTest do
                  Connection.post(
                    url,
                    "{\"variables\":{},\"query\":\"{ users { name } }\"}",
-                   json_headers
+                   %{headers: json_headers, connection_opts: []}
                  )
                )
       end
@@ -39,18 +39,22 @@ defmodule NeuronTest do
     test "it takes all configs as arguments", %{json_headers: json_headers} do
       url = "www.example.com/another/graph"
       headers = ["X-test-header": 'my_header']
+      connection_opts = [timeout: 50_000]
 
       with_mock Connection,
         post: fn _url, _body, _headers ->
           {:ok, %{body: ~s/{"data": {"users": []}}/, status_code: 200, headers: []}}
         end do
-        Neuron.query("{ users { name } }", %{}, url: url, headers: headers)
+        Neuron.query("{ users { name } }", %{}, url: url, headers: headers, connection_opts: connection_opts)
 
         assert called(
                  Connection.post(
                    url,
                    "{\"variables\":{},\"query\":\"{ users { name } }\"}",
-                   Keyword.merge(json_headers, headers)
+                   %{
+                     headers: Keyword.merge(json_headers, headers),
+                     connection_opts: connection_opts
+                    }
                  )
                )
       end


### PR DESCRIPTION
This feature enables the `:connection_opts` config setting to be passed as an argument to `query/3`, which then will override the global config setting.  