### PR TITLE
feat(fragment): recursively embed fragments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,7 @@ erl_crash.dump
 
 # Also ignore archive artifacts (built via "mix archive.build").
 *.ez
+
+/.elixir_ls/
+
+*.coverdata


### PR DESCRIPTION
Currently fragment support is only for a single level of include, which reduces the usefulness of that as a feature as more reusable components can't be composed.

This PR:

- parses fragments at parse-time for any other fragment references
- adds a list of those references into the store
- at runtime, loads extra dependent fragments from the store
- merges them into the query string

I'm not entirely sure what the nicest implementation is here, super happy to discuss and re-implement if you'd prefer.