### PR TITLE
ci(travis): Enforce that code is formatted and that credo shows no warnings with elixir 1.9.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,12 @@ elixir:
   - 1.6.6
   - 1.7.4
   - 1.8.2
+  - 1.9.1
+
+jobs:
+  include:
+    - stage: check style guide
+      elixir: 1.9.1
+      script:
+        - mix format --check-formatted
+        - mix credo

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ elixir:
 
 jobs:
   include:
-    - stage: check style guide
+    - stage: lint
       elixir: 1.9.1
       script:
         - mix format --check-formatted

--- a/README.md
+++ b/README.md
@@ -103,9 +103,14 @@ To run the tests
 mix test
 ```
 
-To run the lint
+## Style guide
+
+Code is formatted with `mix format` and `mix credo` should not show warnings.
+
+To format the code and run static code analysis with credo
 
 ```elixir
+mix format
 mix credo
 ```
 


### PR DESCRIPTION
Added elixir 1.9.1 the list of versions to test.
Added a style guide section in the readme.