### PR TITLE
Fix syntax typo in example response

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ iex> Neuron.query("""
 
 # Response will be:
 
-{:ok, %Neuron.Response{body: %{"data" => {"films" => { "count": 123 }}}%, status_code: 200, headers: []}}
+{:ok, %Neuron.Response{body: %{"data" => %{"films" => %{ "count": 123 }}}, status_code: 200, headers: []}}
 
 # You can also run mutations
 


### PR DESCRIPTION
The example response in README.md is invalid elixir syntax, which confuses newcomers.