### PR TITLE
Add Testing modules and info to README about it

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ A GraphQL client for Elixir.
 
 - [Installation](#installation)
 - [Usage](#usage)
+- [Testing](#testing)
 - [Running Locally](#running-locally)
 - [Contributing](#contributing)
 
@@ -81,6 +82,49 @@ iex> Neuron.query("""
 ```
 
 More extensive documentation can be found at [https://hexdocs.pm/neuron](https://hexdocs.pm/neuron).
+
+## Testing
+
+There is a testing framework provided. To use it set in your application config `config :neuron, testing_mode: true`.
+
+Then write tests using provided helpers:
+
+```elixir
+defmodule SomeApp.ResourcesTest do
+  use ExUnit.Case
+
+  use Neuron.Testing.UnitTest
+
+  alias Neuron.Testing.ValidationAssertion
+
+  describe "when provided with correct response" do
+    setup do
+      response = generate_example_response()
+
+      FakeNeuron.initialize_response({:ok, response})
+      :ok
+    end
+
+    neuron_called_test times: 1, name: "it must call neuron query" do
+      Module.call_query()
+    end
+
+    neuron_query_test "it must call neuron with provided headers" do
+      assertion.(%ValidationAssertion{
+        field: :keywords,
+        validation: fn keywords ->
+          Keyword.get(keywords, :headers) == ["header_1": "some_header"]
+        end,
+        message: "Wrong headers in the graphql query."
+      })
+
+      operation.(
+        Module.call_query()
+      )
+    end
+  end
+end
+```
 
 ## Running locally
 

--- a/lib/neuron.ex
+++ b/lib/neuron.ex
@@ -86,18 +86,25 @@ defmodule Neuron do
   )
   ```
   """
+  if Application.get_env(:neuron, :testing_mode) == true do
+    @spec query(query_string :: String.t(), variables :: Map.t(), options :: keyword()) ::
+            {:ok, Neuron.Response.t()} | {:error, Neuron.Response.t() | Neuron.JSONParseError.t()}
+    def query(query_string, variables \\ %{}, options \\ []) do
+      Neuron.Testing.FakeNeuron.query(query_string, variables, options)
+    end
+  else
+    @spec query(query_string :: String.t(), variables :: Map.t(), options :: keyword()) ::
+            {:ok, Neuron.Response.t()} | {:error, Neuron.Response.t() | Neuron.JSONParseError.t()}
+    def query(query_string, variables \\ %{}, options \\ []) do
+      json_library = json_library(options)
 
-  @spec query(query_string :: String.t(), variables :: Map.t(), options :: keyword()) ::
-          {:ok, Neuron.Response.t()} | {:error, Neuron.Response.t() | Neuron.JSONParseError.t()}
-  def query(query_string, variables \\ %{}, options \\ []) do
-    json_library = json_library(options)
-
-    query_string
-    |> Fragment.insert_into_query()
-    |> build_body()
-    |> insert_variables(variables)
-    |> json_library.encode!()
-    |> run(options)
+      query_string
+      |> Fragment.insert_into_query()
+      |> build_body()
+      |> insert_variables(variables)
+      |> json_library.encode!()
+      |> run(options)
+    end
   end
 
   @doc """

--- a/lib/neuron/testing/fake_neuron.ex
+++ b/lib/neuron/testing/fake_neuron.ex
@@ -1,0 +1,77 @@
+defmodule Neuron.Testing.FakeNeuron do
+  @moduledoc """
+  This is a mock-replacement for Neuron module.
+  """
+
+  use Agent
+
+  def setup_all(assert_function) do
+    Agent.start_link(fn -> assert_function end, name: :assert_function)
+    Agent.start_link(fn -> "" end, name: :query)
+    Agent.start_link(fn -> 0 end, name: :counter)
+    Agent.start_link(fn -> [] end, name: :assertions)
+    Agent.start_link(fn -> [] end, name: :queries)
+  end
+
+  def initialize_response(response) do
+    Agent.update(:query, fn _ -> response end)
+    Agent.update(:counter, fn _ -> 0 end)
+    Agent.update(:assertions, fn _ -> [] end)
+    Agent.update(:queries, fn _ -> [] end)
+  end
+
+  def value, do: Agent.get(:query, & &1)
+
+  def counter, do: Agent.get(:counter, & &1)
+
+  def set_response(response), do: Agent.update(:query, fn _ -> response end)
+
+  def query(query, params, keywords) do
+    Agent.update(:counter, fn state -> state + 1 end)
+
+    Agent.update(:queries, fn queries ->
+      [%{query: query, params: params, keywords: keywords} | queries]
+    end)
+
+    value()
+  end
+
+  def queries, do: Agent.get(:queries, & &1)
+  def assertions, do: Agent.get(:assertions, & &1)
+
+  @spec add_assertion(ValidationAssertion.t()) :: atom()
+  def add_assertion(assertion),
+    do: Agent.update(:assertions, fn assertions -> [assertion | assertions] end)
+
+  def valid? do
+    Enum.each(validate(), fn %Neuron.Testing.ValidationResult{result: result, message: message} ->
+      assert_function().(result, message)
+    end)
+  end
+
+  defp assert_function do
+    Agent.get(:assert_function, & &1)
+  end
+
+  defp validate do
+    Enum.map(
+      assertions(),
+      fn %Neuron.Testing.ValidationAssertion{
+           field: field_name,
+           validation: validation_lambda,
+           message: message
+         } ->
+        %Neuron.Testing.ValidationResult{
+          message: message,
+          result:
+            Enum.any?(
+              queries(),
+              fn stored_query ->
+                validation_lambda.(stored_query[field_name])
+              end
+            )
+        }
+      end
+    )
+  end
+end

--- a/lib/neuron/testing/unit_test.ex
+++ b/lib/neuron/testing/unit_test.ex
@@ -1,0 +1,74 @@
+defmodule Neuron.Testing.UnitTest do
+  @moduledoc ~S"""
+  A module used for testing Neuron queries (using FakeNeuron mock implementation).
+
+  ## Example
+    use Neuron.Testing.UnitTest
+  """
+  alias Neuron.Testing.FakeNeuron, as: FakeNeuron
+
+  @doc ~S"""
+  Setup a test to be used as Neuron query test. Called automatically when module is requested by `use`.
+  """
+  defmacro __using__(_opts) do
+    quote do
+      import Neuron.Testing.UnitTest,
+        only: [neuron_query_test: 2, neuron_called_test: 2]
+
+      alias Neuron.Testing.FakeNeuron, as: FakeNeuron
+
+      setup_all do
+        FakeNeuron.setup_all(&assert/2)
+        :ok
+      end
+    end
+  end
+
+  @doc ~S"""
+  Write a test that will be checking Neuron query using provided assertions.
+
+  ## Example
+    neuron_query_test "it must call neuron with provided headers" do
+      assertion.(%ValidationAssertion{
+        field: :keywords,
+        validation: fn keywords ->
+          Keyword.get(keywords, :headers) == ["some-header": "1", "some-header2": "2"]
+        end,
+        message: "Wrong headers in the graphql query."
+      })
+
+      operation.(
+        SomeModuleCallingNeuron.new()
+      )
+    end
+
+  """
+  defmacro neuron_query_test(name, do: block) do
+    quote do
+      test unquote(name) do
+        var!(assertion) = fn condition -> FakeNeuron.add_assertion(condition) end
+        var!(operation) = fn command -> command end
+        unquote(block)
+        FakeNeuron.valid?()
+      end
+    end
+  end
+
+  @doc ~S"""
+  Write a test that will be checking if Neuron query is called specified number of times.
+
+  ## Example
+    neuron_called_test times: 1, name: "it must call neuron with provided headers" do
+      SomeModuleCallingNeuron.new()
+    end
+
+  """
+  defmacro neuron_called_test(keywords, do: block) do
+    quote do
+      test unquote(keywords |> Keyword.get(:name)) do
+        unquote(block)
+        assert FakeNeuron.counter() == unquote(keywords |> Keyword.get(:times))
+      end
+    end
+  end
+end

--- a/lib/neuron/testing/validation_assertion.ex
+++ b/lib/neuron/testing/validation_assertion.ex
@@ -1,0 +1,23 @@
+defmodule Neuron.Testing.ValidationAssertion do
+  @moduledoc ~S"""
+  A module representing a condition to be checked in Neuron query test.
+
+  ## Example
+    %Neuron.Testing.ValidationAssertion{
+      field: :keywords,
+      validation: fn keywords ->
+        Keyword.get(keywords, :headers) == ["some-header": "1", "some-header2": "2"]
+      end,
+      message: "Wrong headers in the graphql query."
+    }
+  """
+  @fields [:field, :validation, :message]
+  @enforce_keys @fields
+  defstruct @fields
+
+  @type t :: %__MODULE__{
+          field: atom(),
+          validation: (term() -> boolean()),
+          message: String.t()
+        }
+end

--- a/lib/neuron/testing/validation_result.ex
+++ b/lib/neuron/testing/validation_result.ex
@@ -1,0 +1,8 @@
+defmodule Neuron.Testing.ValidationResult do
+  @moduledoc ~S"""
+  A module representing a result of Neuron test validation.
+  """
+  @fields [:result, :message]
+  @enforce_keys @fields
+  defstruct @fields
+end


### PR DESCRIPTION
This PR adds a mechanism to write tests checking Neuron queries and validating it against provided lambdas.

We have been using it for quite some time in our internal projects and extracted it to the upstream in this PR.