### PR TITLE
add Neuron.MissingFragmentsError and raise with formatted missing fragments

### DIFF
--- a/lib/neuron/fragment.ex
+++ b/lib/neuron/fragment.ex
@@ -100,14 +100,3 @@ defmodule Neuron.Fragment do
     end
   end
 end
-
-defmodule Neuron.MissingFragmentsError do
-  defexception [:missing_fragments, message: "Missing fragments"]
-
-  @impl true
-  def message(exception) do
-    missing_fragments = Enum.join(exception.missing_fragments, ", ")
-
-    "Fragments #{missing_fragments} not found"
-  end
-end

--- a/lib/neuron/fragment.ex
+++ b/lib/neuron/fragment.ex
@@ -54,7 +54,8 @@ defmodule Neuron.Fragment do
 
     missing_fragments = fragments_to_add |> Enum.filter(&is_atom/1) |> Enum.map(&Atom.to_string/1)
 
-    if Enum.any?(missing_fragments), do: raise Neuron.MissingFragmentsError, missing_fragments: missing_fragments
+    if Enum.any?(missing_fragments),
+      do: raise(Neuron.MissingFragmentsError, missing_fragments: missing_fragments)
 
     fragments_to_add
     |> Enum.map(&elem(&1, 1))

--- a/lib/neuron/fragment.ex
+++ b/lib/neuron/fragment.ex
@@ -54,7 +54,7 @@ defmodule Neuron.Fragment do
 
     missing_fragments = fragments_to_add |> Enum.filter(&is_atom/1) |> Enum.map(&Atom.to_string/1)
 
-    if Enum.any?(missing_fragments), do: raise("Fragments #{missing_fragments} not found")
+    if Enum.any?(missing_fragments), do: raise Neuron.MissingFragmentsError, missing_fragments: missing_fragments
 
     fragments_to_add
     |> Enum.map(&elem(&1, 1))
@@ -98,5 +98,16 @@ defmodule Neuron.Fragment do
       _ ->
         loaded
     end
+  end
+end
+
+defmodule Neuron.MissingFragmentsError do
+  defexception [:missing_fragments, message: "Missing fragments"]
+
+  @impl true
+  def message(exception) do
+    missing_fragments = Enum.join(exception.missing_fragments, ", ")
+
+    "Fragments #{missing_fragments} not found"
   end
 end

--- a/lib/neuron/missing_fragments_error.ex
+++ b/lib/neuron/missing_fragments_error.ex
@@ -1,0 +1,10 @@
+defmodule Neuron.MissingFragmentsError do
+  defexception [:missing_fragments, message: "Missing fragments"]
+
+  @impl true
+  def message(exception) do
+    missing_fragments = Enum.join(exception.missing_fragments, ", ")
+
+    "Fragments #{missing_fragments} not found"
+  end
+end

--- a/test/neuron/fragment_test.exs
+++ b/test/neuron/fragment_test.exs
@@ -63,8 +63,12 @@ defmodule Neuron.FragmentTest do
     setup [:clear_stored_fragments]
 
     test "query containing fragments error" do
-      assert_raise RuntimeError, fn ->
+      assert_raise Neuron.MissingFragmentsError, "Fragments Name not found", fn ->
         Neuron.query(@test_query_with_fragment)
+      end
+
+      assert_raise Neuron.MissingFragmentsError, "Fragments Name, MemberDetails not found", fn ->
+        Neuron.query(@test_query_with_recursive_fragment)
       end
     end
   end


### PR DESCRIPTION
@uesteibar follow-up to the PR https://github.com/uesteibar/neuron/pull/38, this adds a Neuron.MissingFragmentsError and uses that for raising. Making a PR because there does not seem like anything was done so far and hope this is fine. Let me know if you want any adjustment here.