### PR TITLE
add spelling fix and update to use atom syntax for map, update never reaching function call

### DIFF
--- a/lib/neuron/connection.ex
+++ b/lib/neuron/connection.ex
@@ -5,7 +5,7 @@ defmodule Neuron.Connection do
     raise ArgumentError, message: "you need to supply an url"
   end
 
-  def post(url, query, %{:headers => headers, :connection_opts => connection_opts}) do
+  def post(url, query, %{headers: headers, connection_opts: connection_opts}) do
     HTTPoison.post(
       url,
       query,

--- a/lib/neuron/connection.ex
+++ b/lib/neuron/connection.ex
@@ -1,7 +1,7 @@
 defmodule Neuron.Connection do
   @moduledoc false
 
-  def post(nil, _) do
+  def post(nil, _, _) do
     raise ArgumentError, message: "you need to supply an url"
   end
 

--- a/lib/neuron/store.ex
+++ b/lib/neuron/store.ex
@@ -27,7 +27,7 @@ defmodule Neuron.Store do
   end
 
   @doc """
-  returs neuron application/process environmental variables
+  returns neuron application/process environmental variables
 
   ## Examples
       iex> Neuron.Store.set(:my_key, "value")

--- a/test/neuron/connection_test.exs
+++ b/test/neuron/connection_test.exs
@@ -11,6 +11,12 @@ defmodule Neuron.ConnectionTest do
       %{url: "http://www.example.com/graph", query: %{}}
     end
 
+    test "missing url raises", %{query: query} do
+      assert_raise ArgumentError, "you need to supply an url", fn ->
+        Connection.post(nil, query, %{headers: [], connection_opts: []})
+      end
+    end
+
     test "with basic auth", %{url: url, query: query} do
       with_mock HTTPoison,
         post: fn _url, _query, _headers, _opts ->


### PR DESCRIPTION
- It does not look like `Neuron.Connection.post/2` is ever going to be reached. I updated it to be `Neuron.Connection.post/3` instead
- Found a spelling error for `Neuron.Store.set` doc
- Updated `Neuron.Connection.post/3` function head to use atom shorthand for maps