### PR TITLE
Remove duplicate registered fragments when inserting fragments into query

### DIFF
--- a/lib/neuron/fragment.ex
+++ b/lib/neuron/fragment.ex
@@ -65,9 +65,9 @@ defmodule Neuron.Fragment do
 
   defp find_in_query(query_string) do
     Regex.scan(~r/(?<=\.\.\.)\w+(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/, query_string)
-    |> List.flatten
+    |> List.flatten()
     |> Enum.map(&String.to_atom/1)
-    |> Enum.uniq
+    |> Enum.uniq()
   end
 
   defp construct_fragment_string(fragment_string) do

--- a/lib/neuron/fragment.ex
+++ b/lib/neuron/fragment.ex
@@ -65,8 +65,9 @@ defmodule Neuron.Fragment do
 
   defp find_in_query(query_string) do
     Regex.scan(~r/(?<=\.\.\.)\w+(?=(?:[^\"]*\"[^\"]*\")*[^\"]*$)/, query_string)
-    |> List.flatten()
+    |> List.flatten
     |> Enum.map(&String.to_atom/1)
+    |> Enum.uniq
   end
 
   defp construct_fragment_string(fragment_string) do

--- a/test/neuron/connection/http_test.exs
+++ b/test/neuron/connection/http_test.exs
@@ -104,7 +104,8 @@ defmodule Neuron.Connection.HttpTest do
         json_library = unquote(json_library)
 
         result =
-          Connection.Http.handle_response({:ok, response},
+          Connection.Http.handle_response(
+            {:ok, response},
             json_library: json_library,
             parse_options: [keys: :atoms]
           )

--- a/test/neuron/fragment_test.exs
+++ b/test/neuron/fragment_test.exs
@@ -52,6 +52,17 @@ defmodule Neuron.FragmentTest do
     }
   """
 
+  @test_query_with_repeated_fragments """
+    query users {
+      user(id: 123) {
+        ...Name
+      }
+      user(id: 456) {
+        ...Name
+      }
+    }
+  """
+
   @test_mutation_with_quoted_fragment """
     mutation user(email: "...Name@gmail.com") {
       firstName
@@ -122,6 +133,16 @@ defmodule Neuron.FragmentTest do
       resolved = Fragment.insert_into_query(@test_query_with_recursive_fragment)
 
       assert Regex.scan(~r/fragment\s+Name/, resolved) |> length() == 1
+    end
+  end
+
+  describe "when query contains repeated fragments in one body" do
+    setup [:clear_stored_fragments, :register_name_fragment]
+
+    test "fragments are not duplicated during the execution of find_in_query/1" do
+      resolved = Fragment.insert_into_query(@test_query_with_repeated_fragments)
+
+      assert Regex.scan(~r/fragment/, resolved) |> length() == 1
     end
   end
 

--- a/test/neuron_test.exs
+++ b/test/neuron_test.exs
@@ -54,7 +54,9 @@ defmodule NeuronTest do
           call: fn _body, _options ->
             {:ok, %{body: ~s/{"data": {"users": []}}/, status_code: 200, headers: []}}
           end do
-          Neuron.query("{ users { name } }", %{},
+          Neuron.query(
+            "{ users { name } }",
+            %{},
             url: url,
             headers: headers,
             connection_opts: connection_opts,


### PR DESCRIPTION
Hello!

This PR closes #56

When fragments are used multiple times within the body of a query, they are registered in duplicate
for the number of times they appear in the body.  The duplicates are now filtered out in
find_in_query/1 using Enum.uniq before being inserted into the query.

All tests pass.