### PR TITLE
fix(neuron.connection.http): fix error case so return value matches t…

### DIFF
--- a/lib/neuron/connection/http.ex
+++ b/lib/neuron/connection/http.ex
@@ -40,7 +40,7 @@ defmodule Neuron.Connection.Http do
 
   defp handle({:ok, response}, json_library, parse_options) do
     case json_library.decode(response.body, parse_options) do
-      {:ok, body} -> build_response(%{response | body: body})
+      {:ok, body} -> build_response_tuple(%{response | body: body})
       {:error, error} -> handle_unparsable(response, error)
       {:error, error, _} -> handle_unparsable(response, error)
     end
@@ -48,25 +48,25 @@ defmodule Neuron.Connection.Http do
 
   defp handle({:error, _} = response, _, _), do: response
 
-  defp build_response(%{status_code: 200} = response) do
-    {
-      :ok,
-      %Response{
-        status_code: response.status_code,
-        body: response.body,
-        headers: response.headers
-      }
+  defp build_response(response) do
+    %Response{
+      status_code: response.status_code,
+      body: response.body,
+      headers: response.headers
     }
   end
 
-  defp build_response(response) do
+  defp build_response_tuple(%{status_code: 200} = response) do
+    {
+      :ok,
+      build_response(response)
+    }
+  end
+
+  defp build_response_tuple(response) do
     {
       :error,
-      %Response{
-        status_code: response.status_code,
-        body: response.body,
-        headers: response.headers
-      }
+      build_response(response)
     }
   end
 

--- a/lib/neuron/connection/http.ex
+++ b/lib/neuron/connection/http.ex
@@ -48,14 +48,6 @@ defmodule Neuron.Connection.Http do
 
   defp handle({:error, _} = response, _, _), do: response
 
-  defp build_response(response) do
-    %Response{
-      status_code: response.status_code,
-      body: response.body,
-      headers: response.headers
-    }
-  end
-
   defp build_response_tuple(%{status_code: 200} = response) do
     {
       :ok,
@@ -67,6 +59,14 @@ defmodule Neuron.Connection.Http do
     {
       :error,
       build_response(response)
+    }
+  end
+
+  defp build_response(response) do
+    %Response{
+      status_code: response.status_code,
+      body: response.body,
+      headers: response.headers
     }
   end
 

--- a/test/neuron/connection/http_test.exs
+++ b/test/neuron/connection/http_test.exs
@@ -202,8 +202,19 @@ defmodule Neuron.Connection.HttpTest do
         body = "<html><body>This is not the GraphQL URL</body></html>"
         raw_response = build_response(200, body)
 
-        assert {:error, %JSONParseError{}} =
+        assert {:error, parse_error} =
                  Connection.Http.handle_response({:ok, raw_response}, json_library: json_library)
+
+        assert is_map(parse_error)
+        assert :erlang.is_map_key(:__struct__, parse_error)
+        assert :erlang.map_get(:__struct__, parse_error) == JSONParseError
+
+        assert %JSONParseError{error: error, response: response} = parse_error
+
+        assert is_map(error)
+        assert is_map(response)
+        assert :erlang.is_map_key(:__struct__, response)
+        assert :erlang.map_get(:__struct__, response) == Response
       end
     end
 
@@ -213,7 +224,7 @@ defmodule Neuron.Connection.HttpTest do
         body = "<html><body>This is not the GraphQL URL</body></html>"
         raw_response = build_response(200, body)
 
-        assert {_, %{response: {:ok, %Response{} = response}}} =
+        assert {_, %{response: %Response{} = response}} =
                  Connection.Http.handle_response({:ok, raw_response}, json_library: json_library)
 
         assert response.body == raw_response.body

--- a/test/neuron/connection/http_test.exs
+++ b/test/neuron/connection/http_test.exs
@@ -206,15 +206,15 @@ defmodule Neuron.Connection.HttpTest do
                  Connection.Http.handle_response({:ok, raw_response}, json_library: json_library)
 
         assert is_map(parse_error)
-        assert :erlang.is_map_key(:__struct__, parse_error)
-        assert :erlang.map_get(:__struct__, parse_error) == JSONParseError
+        assert :maps.is_key(:__struct__, parse_error)
+        assert :maps.get(:__struct__, parse_error) == JSONParseError
 
         assert %JSONParseError{error: error, response: response} = parse_error
 
         assert is_map(error)
         assert is_map(response)
-        assert :erlang.is_map_key(:__struct__, response)
-        assert :erlang.map_get(:__struct__, response) == Response
+        assert :maps.is_key(:__struct__, response)
+        assert :maps.get(:__struct__, response) == Response
       end
     end
 


### PR DESCRIPTION
…ypespec

The definition of the `JSONParseError` struct says that the `response` element is a
`Neuron.Response.t()`, but the code was actually returning a tuple (`{:error,
Neuron.Response.t()}`). With this change the type of `response` matches the typespec.

BREAKING CHANGE: If your code expects the `response` field of `JSONParseError` to be a tuple, it
will break.

fix #59