### PR TITLE
refactor(behaviour): Make behaviour for Neuron

### DIFF
--- a/lib/neuron.ex
+++ b/lib/neuron.ex
@@ -87,9 +87,9 @@ defmodule Neuron do
 
   alias Neuron.{ConfigUtils, Fragment}
 
-  @spec query(query_string :: String.t(), variables :: map(), options :: keyword()) ::
-          {:ok, Neuron.Response.t()}
-          | {:error, Neuron.Response.t() | Neuron.JSONParseError.t() | HTTPoison.Error.t()}
+  @behaviour Neuron.Behaviour
+
+  @impl Neuron.Behaviour
   def query(query_string, variables \\ %{}, options \\ []) do
     json_library = ConfigUtils.json_library(options)
 

--- a/lib/neuron/behaviour.ex
+++ b/lib/neuron/behaviour.ex
@@ -1,0 +1,7 @@
+defmodule Neuron.Behaviour do
+  @moduledoc false
+
+  @callback query(query_string :: String.t(), variables :: map(), options :: keyword()) ::
+              {:ok, Neuron.Response.t()}
+              | {:error, Neuron.Response.t() | Neuron.JSONParseError.t() | HTTPoison.Error.t()}
+end


### PR DESCRIPTION
This makes Neuron a behaviour module and describes how to mock it in the test.

It can now be used directly with Mox without a wrapping module.
I know you use mock, but it's a good thing to give the user a choice between mock and mox.

